### PR TITLE
Adjust requirements.txt and poetry.lock

### DIFF
--- a/ariel/poetry.lock
+++ b/ariel/poetry.lock
@@ -80,7 +80,7 @@ python-versions = "*"
 
 [[package]]
 name = "grpcio"
-version = "1.43.0"
+version = "1.41.0"
 description = "HTTP/2-based RPC framework"
 category = "main"
 optional = false
@@ -90,7 +90,7 @@ python-versions = ">=3.6"
 six = ">=1.5.2"
 
 [package.extras]
-protobuf = ["grpcio-tools (>=1.43.0)"]
+protobuf = ["grpcio-tools (>=1.41.0)"]
 
 [[package]]
 name = "huggingface-hub"

--- a/tutorials/requirements.txt
+++ b/tutorials/requirements.txt
@@ -1,7 +1,7 @@
-grpcio==1.43.0
+grpcio==1.41.0
 numpy==1.21.4
-onnxruntime==1.8.0
 Pillow==9.1.0
 torch==1.11.0
 transformers==4.18.0
 tritonclient[grpc]==2.21.0
+onnxruntime==1.8.0


### PR DESCRIPTION
* Pin grpc to 1.41 to keep with triton 2.21.0
* move onnxruntime to the end of requirements.txt for 3.10 users (it
  will still fail but at least they'll get the rest of the packages)