### PR TITLE
Add the rest of tutorials to CI

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -26,7 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-
     # Setup the working directory
     - uses: actions/checkout@v2
     - name: Make parent dirs for octoml-bin
@@ -46,10 +45,12 @@ jobs:
     - run: pip install -r tutorials/requirements.txt
 
     # Install dependencies
-    - name: Run setup.sh
+    - name: Run setup.sh --model=""
       run: cd tutorials && ./setup.sh
     - name: Run setup-cloud.sh
       run: cd tutorials && ./setup-cloud.sh
+    - name: Check disk space
+      run: df -h && docker system df
 
     # Vision tutorial
     - name: Build vision model
@@ -99,9 +100,11 @@ jobs:
 
     # Install dependencies
     - name: Run setup.sh
-      run: cd tutorials && ./setup.sh
+      run: cd tutorials && ./setup.sh --model="qa"
     - name: Run setup-cloud.sh
       run: cd tutorials && ./setup-cloud.sh
+    - name: Check disk space
+      run: df -h && docker system df
 
     # QA tutorial
     - name: Build QA model
@@ -151,9 +154,11 @@ jobs:
 
     # Install dependencies
     - name: Run setup.sh
-      run: cd tutorials && ./setup.sh
+      run: cd tutorials && ./setup.sh --model="gpt"
     - name: Run setup-cloud.sh
       run: cd tutorials && ./setup-cloud.sh
+    - name: Check disk space
+      run: df -h && docker system df
 
     # Generation tutorial
     - name: Build generation model

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -66,6 +66,27 @@ jobs:
       run: cd tutorials && ./setup.sh
     - name: Run setup-cloud.sh
       run: cd tutorials && ./setup-cloud.sh
+    - name: Run docker prune and check disk
+      run: |
+        docker system prune -a -f
+        df -h
+
+    # QA tutorial
+    - name: Build QA model
+      run: cd tutorials/question_answering && $OCTOML deploy
+    - name: Docker check running
+      run: sleep 4  && ps -ef | grep 8000
+    - name: Execute question_answering model with native grpc
+      run: cd tutorials/question_answering && python run.py --triton
+    - name: Execute question_answering model with python grpc
+      run: cd tutorials/question_answering && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
+    - name: Clean up after deployment
+      run: |
+        df -h
+        docker kill $(docker ps -q)
+        docker rmi $(docker images bert -q)
+        docker system df
+        df -h
 
     # Vision tutorial
     - name: Build vision model
@@ -80,3 +101,27 @@ jobs:
       run: cd tutorials/vision && python run.py --triton --protocol http --port 8000
     - name: Kill deployment
       run: docker kill $(docker ps -q)
+    - name: Clean up after deployment
+      run: |
+        df -h
+        docker kill $(docker ps -q)
+        docker rmi $(docker images critterblock -q)
+        docker system df
+        df -h
+
+    # Generation tutorial
+    - name: Build generation model
+      run: cd tutorials/generation && $OCTOML deploy
+    - name: Docker check running
+      run: sleep 4  && ps -ef | grep 8000
+    - name: Execute generation model with native grpc
+      run: cd tutorials/generation && python run.py --triton
+    - name: Execute generation model with python grpc
+      run: cd tutorials/generation && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
+    - name: Clean up after deployment
+      run: |
+        df -h
+        docker kill $(docker ps -q)
+        docker rmi $(docker images gpt2-lm-head-10 -q)
+        docker system df
+        df -h

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,11 +21,48 @@ jobs:
     - uses: actions/checkout@v2
     - name: Run Shellcheck
       uses: ludeeus/action-shellcheck@1.1.0
-  runtest:
+
+  runtest-vision:
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 15
     steps:
 
+    # Setup the working directory
+    - uses: actions/checkout@v2
+    - name: Make parent dirs for octoml-bin
+      run: mkdir -p target/debug
+    - name: Download octoml-bin (tar.gz)
+      run: curl --fail ${{secrets.CLI_DOWNLOAD_LINK_UBUNTU}} --output octoml.tar.gz && tar xzf octoml.tar.gz && mv octoml target/debug/octoml
+    - name: Show Download
+      run: ls -lR target/debug/octoml
+    - name: chmod octoml bin
+      run: chmod 775 target/debug/octoml
+    - name: Print octoml version
+      run: $OCTOML -V
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+        cache: 'pip'
+    - run: pip install -r tutorials/requirements.txt
+
+    # Install dependencies
+    - name: Run setup.sh
+      run: cd tutorials && ./setup.sh
+    - name: Run setup-cloud.sh
+      run: cd tutorials && ./setup-cloud.sh
+
+    # Vision tutorial
+    - name: Build vision model
+      run: cd tutorials/vision && $OCTOML deploy
+    - name: Docker check running
+      run: sleep 4  && ps -ef | grep 8000
+    - name: Run tutorial test
+      run: cd tutorials && bash tests/test_tutorial.sh vision
+
+  runtest-qa:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
     # Setup the working directory
     - uses: actions/checkout@v2
     - name: Make parent dirs for octoml-bin
@@ -48,7 +85,7 @@ jobs:
     - name: Cache huggingface
       uses: actions/cache@v3
       with:
-        key: cache-huggingface
+        key: cache-huggingface-qa
         path: ~/.cache/huggingface
 
     # Download models
@@ -56,10 +93,9 @@ jobs:
       id: cache-models
       uses: actions/cache@v3
       with:
-        key: cache-models-${{ hashFiles('tutorials/download_model.sh') }}
+        key: cache-models-qa-${{ hashFiles('tutorials/download_model.sh') }}
         path: |
           tutorials/question_answering/model.onnx
-          # tutorials/generation/gpt2-lm-head-10.onnx
 
     # Install dependencies
     - name: Run setup.sh
@@ -74,40 +110,55 @@ jobs:
       run: sleep 4  && ps -ef | grep 8000
     - name: Run tutorial test
       run: cd tutorials && bash tests/test_tutorial.sh question_answering
-    - name: Clean up after deployment
-      run: |
-        df -h
-        docker system df
-        docker images
+   
+  runtest-generation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    # Setup the working directory
+    - uses: actions/checkout@v2
+    - name: Make parent dirs for octoml-bin
+      run: mkdir -p target/debug
+    - name: Download octoml-bin (tar.gz)
+      run: curl --fail ${{secrets.CLI_DOWNLOAD_LINK_UBUNTU}} --output octoml.tar.gz && tar xzf octoml.tar.gz && mv octoml target/debug/octoml
+    - name: Show Download
+      run: ls -lR target/debug/octoml
+    - name: chmod octoml bin
+      run: chmod 775 target/debug/octoml
+    - name: Print octoml version
+      run: $OCTOML -V
+    - uses: actions/setup-python@v3
+      with:
+        python-version: 3.8
+        cache: 'pip'
+    - run: pip install -r tutorials/requirements.txt
 
-    # Vision tutorial
-    - name: Build vision model
-      run: cd tutorials/vision && $OCTOML deploy
+    # Cache huggingface models
+    - name: Cache huggingface
+      uses: actions/cache@v3
+      with:
+        key: cache-huggingface-generation
+        path: ~/.cache/huggingface
+
+    # Download models
+    - name: Cache models
+      id: cache-models
+      uses: actions/cache@v3
+      with:
+        key: cache-models-gpt-${{ hashFiles('tutorials/download_model.sh') }}
+        path: |
+          tutorials/generation/model.onnx
+
+    # Install dependencies
+    - name: Run setup.sh
+      run: cd tutorials && ./setup.sh
+    - name: Run setup-cloud.sh
+      run: cd tutorials && ./setup-cloud.sh
+
+    # Generation tutorial
+    - name: Build generation model
+      run: cd tutorials/generation && $OCTOML deploy
     - name: Docker check running
       run: sleep 4  && ps -ef | grep 8000
     - name: Run tutorial test
-      run: cd tutorials && bash tests/test_tutorial.sh vision
-    - name: Kill deployment
-      run: docker kill $(docker ps -q)
-    - name: Clean up after deployment
-      run: |
-        df -h
-        docker system df
-        docker images
-
-    # # Generation tutorial
-    # - name: Build generation model
-    #   run: cd tutorials/generation && $OCTOML deploy
-    # - name: Docker check running
-    #   run: sleep 4  && ps -ef | grep 8000
-    # - name: Execute generation model with native grpc
-    #   run: cd tutorials/generation && python run.py --triton
-    # - name: Execute generation model with python grpc
-    #   run: cd tutorials/generation && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
-    # - name: Clean up after deployment
-    #   run: |
-    #     df -h
-    #     docker kill $(docker ps -q)
-    #     docker rmi $(docker images gpt2-lm-head-10 -q)
-    #     docker system df
-    #     df -h
+      run: cd tutorials && bash tests/test_tutorial.sh generation

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       uses: ludeeus/action-shellcheck@1.1.0
   runtest:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 60
     steps:
 
     # Setup the working directory
@@ -44,6 +44,13 @@ jobs:
         cache: 'pip'
     - run: pip install -r tutorials/requirements.txt
 
+    # Cache huggingface models
+    - name: Cache huggingface
+      uses: actions/cache@v3
+      with:
+        key: cache-huggingface
+        path: ~/.cache/huggingface
+
     # Download models
     - name: Cache models
       id: cache-models
@@ -52,76 +59,55 @@ jobs:
         key: cache-models-${{ hashFiles('tutorials/download_model.sh') }}
         path: |
           tutorials/question_answering/model.onnx
-          tutorials/generation/gpt2-lm-head-10.onnx
-
-    # Cache huggingface models
-    - name: Cache huggingface
-      uses: actions/cache@v3
-      with:
-        key: cache-huggingface
-        path: ~/.cache/huggingface
+          # tutorials/generation/gpt2-lm-head-10.onnx
 
     # Install dependencies
     - name: Run setup.sh
       run: cd tutorials && ./setup.sh
     - name: Run setup-cloud.sh
       run: cd tutorials && ./setup-cloud.sh
-    - name: Run docker prune and check disk
-      run: |
-        docker system prune -a -f
-        df -h
 
     # QA tutorial
     - name: Build QA model
       run: cd tutorials/question_answering && $OCTOML deploy
     - name: Docker check running
       run: sleep 4  && ps -ef | grep 8000
-    - name: Execute question_answering model with native grpc
-      run: cd tutorials/question_answering && python run.py --triton
-    - name: Execute question_answering model with python grpc
-      run: cd tutorials/question_answering && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
+    - name: Run tutorial test
+      run: cd tutorials && bash tests/test_tutorial.sh question_answering
     - name: Clean up after deployment
       run: |
         df -h
-        docker kill $(docker ps -q)
-        docker rmi $(docker images bert -q)
         docker system df
-        df -h
+        docker images
 
     # Vision tutorial
     - name: Build vision model
       run: cd tutorials/vision && $OCTOML deploy
     - name: Docker check running
       run: sleep 4  && ps -ef | grep 8000
-    - name: Execute vision model with native grpc
-      run: cd tutorials/vision && python run.py --triton
-    - name: Execute vision model with python grpc
-      run: cd tutorials/vision && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
-    - name: Execute vision model with http
-      run: cd tutorials/vision && python run.py --triton --protocol http --port 8000
+    - name: Run tutorial test
+      run: cd tutorials && bash tests/test_tutorial.sh vision
     - name: Kill deployment
       run: docker kill $(docker ps -q)
     - name: Clean up after deployment
       run: |
         df -h
-        docker kill $(docker ps -q)
-        docker rmi $(docker images critterblock -q)
         docker system df
-        df -h
+        docker images
 
-    # Generation tutorial
-    - name: Build generation model
-      run: cd tutorials/generation && $OCTOML deploy
-    - name: Docker check running
-      run: sleep 4  && ps -ef | grep 8000
-    - name: Execute generation model with native grpc
-      run: cd tutorials/generation && python run.py --triton
-    - name: Execute generation model with python grpc
-      run: cd tutorials/generation && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
-    - name: Clean up after deployment
-      run: |
-        df -h
-        docker kill $(docker ps -q)
-        docker rmi $(docker images gpt2-lm-head-10 -q)
-        docker system df
-        df -h
+    # # Generation tutorial
+    # - name: Build generation model
+    #   run: cd tutorials/generation && $OCTOML deploy
+    # - name: Docker check running
+    #   run: sleep 4  && ps -ef | grep 8000
+    # - name: Execute generation model with native grpc
+    #   run: cd tutorials/generation && python run.py --triton
+    # - name: Execute generation model with python grpc
+    #   run: cd tutorials/generation && PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
+    # - name: Clean up after deployment
+    #   run: |
+    #     df -h
+    #     docker kill $(docker ps -q)
+    #     docker rmi $(docker images gpt2-lm-head-10 -q)
+    #     docker system df
+    #     df -h

--- a/tutorials/download_model.sh
+++ b/tutorials/download_model.sh
@@ -8,8 +8,8 @@ then
     PYTHON=python3
 fi
 
-# Get the bert model for the question answering demo
-[ -f question_answering/model.onnx ] || ${PYTHON} -m transformers.onnx --model=bert-large-uncased-whole-word-masking-finetuned-squad --feature=question-answering question_answering
+# Get the distilbert model for the question answering demo
+[ -f question_answering/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilbert-base-uncased-distilled-squad --feature=question-answering question_answering
 
-# Get the gpt2 model for the generation model
-[ -f generation/gpt2-lm-head-10.onnx ] || curl -fsSL -o generation/gpt2-lm-head-10.onnx https://github.com/onnx/models/raw/main/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
+# # Get the gpt2 model for the generation model
+# [ -f generation/gpt2-lm-head-10.onnx ] || curl -fsSL -o generation/gpt2-lm-head-10.onnx https://github.com/onnx/models/raw/main/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx

--- a/tutorials/download_model.sh
+++ b/tutorials/download_model.sh
@@ -8,8 +8,28 @@ then
     PYTHON=python3
 fi
 
-# Get the distilbert model for the question answering demo
-[ -f question_answering/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilbert-base-uncased-distilled-squad --feature=question-answering question_answering
+MODEL="all"
+for i in "$@"; do
+  case $i in
+    -m=*|--model=*)
+      MODEL="${i#*=}"
+      shift # past argument=value
+      ;;
+    --*|-*)
+      echo "Unknown option $i"
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
 
+if [[ "$MODEL" == "all" || "$MODEL" == "qa" ]]; then
+# Get the distilbert model for the question answering demo
+  [ -f question_answering/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilbert-base-uncased-distilled-squad --feature=question-answering question_answering
+fi
+
+if [[ "$MODEL" == "all" || "$MODEL" == "gpt" ]]; then
 # Get the gpt2 model for the generation model
-[ -f generation/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilgpt2 --feature=causal-lm generation
+  [ -f generation/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilgpt2 --feature=causal-lm generation
+fi

--- a/tutorials/download_model.sh
+++ b/tutorials/download_model.sh
@@ -11,5 +11,5 @@ fi
 # Get the distilbert model for the question answering demo
 [ -f question_answering/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilbert-base-uncased-distilled-squad --feature=question-answering question_answering
 
-# # Get the gpt2 model for the generation model
-# [ -f generation/gpt2-lm-head-10.onnx ] || curl -fsSL -o generation/gpt2-lm-head-10.onnx https://github.com/onnx/models/raw/main/text/machine_comprehension/gpt-2/model/gpt2-lm-head-10.onnx
+# Get the gpt2 model for the generation model
+[ -f generation/model.onnx ] || ${PYTHON} -m transformers.onnx --model=distilgpt2 --feature=causal-lm generation

--- a/tutorials/generation/octoml.yaml
+++ b/tutorials/generation/octoml.yaml
@@ -1,7 +1,7 @@
 ---
 models:
-  gpt2-lm-head-10:
-    path: gpt2-lm-head-10.onnx
+  distilgpt2:
+    path: model.onnx
     inputs:
       input1:
         shape:

--- a/tutorials/question_answering/octoml.yaml
+++ b/tutorials/question_answering/octoml.yaml
@@ -1,6 +1,6 @@
 ---
 models:
-  bert:
+  distilbert:
     path: model.onnx
     inputs:
       input_ids:

--- a/tutorials/requirements.txt
+++ b/tutorials/requirements.txt
@@ -1,5 +1,4 @@
 protobuf>=3.5.0,<3.20
-ariel-client-triton
 grpcio==1.41.0
 numpy==1.21.4
 Pillow==9.1.1

--- a/tutorials/setup.sh
+++ b/tutorials/setup.sh
@@ -11,5 +11,22 @@ then
     exit 1
 fi
 
-# Download pretrained model into tutorials
-./download_model.sh
+MODEL="all"
+for i in "$@"; do
+  case $i in
+    -m=*|--model=*)
+      MODEL="${i#*=}"
+      shift # past argument=value
+      ;;
+    --*|-*)
+      echo "Unknown option $i"
+      exit 1
+      ;;
+    *)
+      ;;
+  esac
+done
+
+if [[ -n "$MODEL" ]]; then
+  ./download_model.sh "$MODEL"
+fi

--- a/tutorials/tests/test_tutorial.sh
+++ b/tutorials/tests/test_tutorial.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -ex
+TUTORIAL_DIR=$1
+
+# Local test
+cd "$TUTORIAL_DIR"
+python run.py --local
+# Triton native GRPC test
+python run.py --triton
+# Triton python GRPC test
+PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python python run.py --triton
+# Triton http test
+python run.py --triton --protocol http

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -117,7 +117,7 @@ class TritonRemoteModel:
             if len(kwargs) != len(self._infer_inputs):
                 raise RuntimeError("Expect {} inputs got {}".format(len(self._infer_inputs), len(kwargs)))
             for placeholder in self._infer_inputs:
-                value = kwargs[placeholder.name]
+                value = kwargs[placeholder.name()]
                 placeholder.set_shape(value.shape)
                 placeholder.set_data_from_numpy(value)
 

--- a/tutorials/vision/run.py
+++ b/tutorials/vision/run.py
@@ -59,6 +59,7 @@ def run_triton(port: Union[str, None], hostname: str, protocol: str):
         port = '8000' if protocol == 'http' else '8001'
 
     server_url = f'{hostname}:{port}'
+
     # Preprocess input image
     image = Image.open("cat_input_images/prey1.jpeg")
 


### PR DESCRIPTION
All tutorial:
- use triton_client
- support grpc/http

Generation tutorial:
- use smaller distilgpt2 model
- rewrite the code for better readability

QA tutorial:
- use smaller distilbert

Build script:
- setup.sh supports `--model` argument to optionally download a model
- download.sh supports `--model` argument to optionally download a model

CI:
- separate each tutorial into its own workflow to reduce flake due to lack of disk space and improve runtime because of parallelism
- refactor test code into its own script