### PR TITLE
Fix docs and python 3.10.4 support for vision

### DIFF
--- a/tutorials/requirements.txt
+++ b/tutorials/requirements.txt
@@ -6,4 +6,3 @@ torch==1.11.0
 transformers==4.18.0
 tritonclient[grpc,http]==2.22.3
 onnxruntime==1.8.0
-attrdict==2.0.1

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -67,7 +67,7 @@ class TritonRemoteModel:
         self._metadata = self._client.get_model_metadata(model_name, model_version)
         if protocol == 'http':
             self._metadata = SimpleNamespace(**self._metadata)
-        self._infer_inputs = [InferInput(x.name, None, x.datatype) for x in self._metadata.inputs]
+        self._infer_inputs = [InferInput(x["name"], None, x["datatype"]) for x in self._metadata.inputs]
         self._protocol = protocol
 
     @property

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -67,7 +67,7 @@ class TritonRemoteModel:
         self._metadata = self._client.get_model_metadata(model_name, model_version)
         if protocol == 'http':
             self._metadata = SimpleNamespace(**self._metadata)
-            self._inputs = SimpleNamespace(**self._metadata.inputs)
+            self._inputs = [SimpleNamespace(**inputs) for inputs in self._metadata.inputs]
         else:
             self._inputs = self._metadata.inputs
 

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -67,7 +67,9 @@ class TritonRemoteModel:
         self._metadata = self._client.get_model_metadata(model_name, model_version)
         if protocol == 'http':
             self._metadata = SimpleNamespace(**self._metadata)
-        self._infer_inputs = [InferInput(x["name"], None, x["datatype"]) for x in self._metadata.inputs]
+            self._inputs = SimpleNamespace(**self._metadata.inputs)
+
+        self._infer_inputs = [InferInput(x.name, None, x.datatype) for x in self._inputs]
         self._protocol = protocol
 
     @property
@@ -80,7 +82,7 @@ class TritonRemoteModel:
 
     @property
     def inputs(self):
-        return self._metadata.inputs
+        return self._inputs
 
     @property
     def outputs(self):

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -68,6 +68,8 @@ class TritonRemoteModel:
         if protocol == 'http':
             self._metadata = SimpleNamespace(**self._metadata)
             self._inputs = SimpleNamespace(**self._metadata.inputs)
+        else:
+            self._inputs = self._metadata.inputs
 
         self._infer_inputs = [InferInput(x.name, None, x.datatype) for x in self._inputs]
         self._protocol = protocol

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -7,7 +7,8 @@ and `examples<https://github.com/triton-inference-server/client/tree/main/src/py
 
 import numpy as np
 from typing import Union, Tuple
-from attrdict import AttrDict
+from types import SimpleNamespace
+
 try:
     from tritonclient.http import (
         InferenceServerClient as HttpClient,
@@ -65,7 +66,7 @@ class TritonRemoteModel:
         self._version = model_version
         self._metadata = self._client.get_model_metadata(model_name, model_version)
         if protocol == 'http':
-            self._metadata = AttrDict(self._metadata)
+            self._metadata = SimpleNamespace(**self._metadata)
         self._infer_inputs = [InferInput(x.name, None, x.datatype) for x in self._metadata.inputs]
         self._protocol = protocol
 

--- a/tutorials/triton_util.py
+++ b/tutorials/triton_util.py
@@ -68,8 +68,10 @@ class TritonRemoteModel:
         if protocol == 'http':
             self._metadata = SimpleNamespace(**self._metadata)
             self._inputs = [SimpleNamespace(**inputs) for inputs in self._metadata.inputs]
+            self._outputs = [SimpleNamespace(**outputs) for outputs in self._metadata.outputs]
         else:
             self._inputs = self._metadata.inputs
+            self._outputs = self._metadata.outputs
 
         self._infer_inputs = [InferInput(x.name, None, x.datatype) for x in self._inputs]
         self._protocol = protocol
@@ -88,7 +90,7 @@ class TritonRemoteModel:
 
     @property
     def outputs(self):
-        return self._metadata.outputs
+        return self._outputs
 
     @property
     def backend(self):

--- a/tutorials/vision/README.md
+++ b/tutorials/vision/README.md
@@ -7,6 +7,6 @@ This is an example computer vision model for use with `octoml` cli.
 The `onnxruntime` library is a dependency on these tutorials. It currently does not support python `>3.9`. For users locked into `3.10` you can run this vision tutorial by following the below steps. You can also run only `octoml` natively and use an `ubuntu:20.04` docker container to run the inferencing utility, `run.py`.
 
 * Edit `requirements.txt` and remove `onnxruntime`
-* Edit `setup.py` and remove the line that begins with `${PYTHON} -m transformers.onnx`
-* Run `setup.py`
+* Edit `download_model.sh` and remove the lines that begins with `${PYTHON} -m transformers.onnx`
+* Run `setup.sh`
 * Use this example only


### PR DESCRIPTION
This fixes some documentation bugs that reference a `setup.py` file that no longer exists. This also fixes python 3.10.4 support for the vision example by removing `attrdict` which does not seem to have python 3.10.4 support, and is not needed since `types.SimpleNamespace` does the same thing and is builtin to python 3.3+

