### PR TITLE
Added check and message to avoid Exception masking

### DIFF
--- a/tutorials/vision/run.py
+++ b/tutorials/vision/run.py
@@ -13,8 +13,11 @@ from triton_util import TritonRemoteModel  # noqa
 # onnxruntime doesn't support python 3.10
 try:
     from onnxruntime import InferenceSession
-except ImportError:
-    print("onnxruntime doesn't support python 3.10: use --triton, --local won't work")
+except ImportError as e:
+    if sys.version_info.major == 3 and sys.version_info.minor == 10:
+        print("onnxruntime doesn't support python 3.10: use --triton, --local won't work")
+    else:
+        print("not able to import onnxruntime. Check your environment. Did you run ../setup.sh?")
 
 
 def image_preprocess(imgs: List[Image.Image]) -> List[np.ndarray]:


### PR DESCRIPTION
Added a small Python version check.

In the current state if using Python 3.9/3.8 we get a message hinting about 3.10 when there is an issue with the environment.

In theory should not happen if `setup.sh` works correctly, but today it did not correctly setup the venv I had just created. I had to spend a bit of time figuring out what was actually happening.